### PR TITLE
Service setup code changes and small refactoring in pkg/services/employee

### DIFF
--- a/cmd/service.go
+++ b/cmd/service.go
@@ -81,8 +81,6 @@ func run(cmd *cobra.Command, args []string) {
 		}
 	}()
 
-	waitgroup.Gwg.Add(1)
-
 	// listen for C-c
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt)

--- a/pkg/repositories/employee/employee.go
+++ b/pkg/repositories/employee/employee.go
@@ -3,6 +3,7 @@ package employee
 import (
 	"context"
 	"errors"
+	"github.com/jainabhishek5986/employee-records/pkg/repositories"
 	"strconv"
 
 	"github.com/jainabhishek5986/employee-records/pkg/errs"
@@ -18,7 +19,7 @@ type Repository struct {
 	db *gorm.DB
 }
 
-func NewEmployeeRepo(db *gorm.DB) *Repository {
+func NewEmployeeRepo(db *gorm.DB) repositories.EmployeeRepository {
 	return &Repository{db: db}
 }
 

--- a/pkg/services/employee/employee.go
+++ b/pkg/services/employee/employee.go
@@ -2,6 +2,7 @@ package employee
 
 import (
 	"context"
+	"github.com/jainabhishek5986/employee-records/pkg/repositories"
 
 	"github.com/jainabhishek5986/employee-records/pkg/global"
 	"github.com/jainabhishek5986/employee-records/pkg/repositories/employee"
@@ -12,31 +13,31 @@ import (
 // Employee Service Structure
 type service struct {
 	db   *gorm.DB
-	repo employee.Repository
+	repo repositories.EmployeeRepository
 }
 
 func NewService(db *gorm.DB) services.EmployeeService {
 
 	repo := employee.NewEmployeeRepo(db)
-	return &service{db: db, repo: *repo}
+	return &service{db: db, repo: repo}
 }
 
-func (envSvc service) CreateEmployee(ctx context.Context, req global.DecodeEmployeesPOSTRequest) error {
+func (envSvc *service) CreateEmployee(ctx context.Context, req global.DecodeEmployeesPOSTRequest) error {
 	return envSvc.repo.CreateEmployee(ctx, req)
 }
 
-func (envSvc service) GetEmployeeByID(ctx context.Context, id int) (global.SuccessGETInfo, error) {
+func (envSvc *service) GetEmployeeByID(ctx context.Context, id int) (global.SuccessGETInfo, error) {
 	return envSvc.repo.GetEmployeeByID(ctx, id)
 }
 
-func (envSvc service) UpdateEmployeeByID(ctx context.Context, request global.DecodeEmployeePUTRequest) error {
+func (envSvc *service) UpdateEmployeeByID(ctx context.Context, request global.DecodeEmployeePUTRequest) error {
 	return envSvc.repo.UpdateEmployeeByID(ctx, request)
 }
 
-func (envSvc service) DeleteEmployeeByID(ctx context.Context, id int) error {
+func (envSvc *service) DeleteEmployeeByID(ctx context.Context, id int) error {
 	return envSvc.repo.DeleteEmployeeByID(ctx, id)
 }
 
-func (envSvc service) GetAllEmployee(ctx context.Context, queryParams map[string][]string) (global.SuccessGETInfo, error) {
+func (envSvc *service) GetAllEmployee(ctx context.Context, queryParams map[string][]string) (global.SuccessGETInfo, error) {
 	return envSvc.repo.GetAllEmployee(ctx, queryParams)
 }


### PR DESCRIPTION
- Incrementing the wait group in `StartAPIServer` function so for retry logic
- Removed unused done channel from setup logic
- Made the service methods to be pointer receivers
- Using interface as return type for `NewEmployeeRepo` function
